### PR TITLE
update gitconfig rebase for deprecated preserve-merges arg. using rebase-merges

### DIFF
--- a/_gitconfig
+++ b/_gitconfig
@@ -53,4 +53,4 @@
 [init]
     defaultBranch = master
 [pull]
-	rebase = preserve
+    rebase = merges


### PR DESCRIPTION
update gitconfig rebase for deprecated `--preserve-merges` arg. using `--rebase-merges`